### PR TITLE
Add Microphone usage permission description in info.plist to avoid de…

### DIFF
--- a/Demo/SCSiriWaveformView/SCSiriWaveformView-Info.plist
+++ b/Demo/SCSiriWaveformView/SCSiriWaveformView-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Application will use microphone to record audio.</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>


### PR DESCRIPTION
Info.plist is missing the `Privacy - Microphone Usage Description` key which is causing the Demo application to crash. This pull request fixes this issue.